### PR TITLE
Dependency specification and legend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ RoxygenNote: 7.1.2
 Depends: 
     R (>= 4.0.0)
 Imports: tidyr, 
-    readr,
+    readr (>= 2.0.1),
     magrittr,
     dplyr,
     xts,

--- a/R/dfc.R
+++ b/R/dfc.R
@@ -181,7 +181,7 @@ dfc <- function(
   dfc$hp <- as.numeric(dfc$hp)
 
   dfc_plot <- ggplot(dfc, aes(x = date)) +
-    geom_line(aes(y = dfc, linetype = "Degree of functional coupling (%)")) +
+    geom_line(aes(y = dfc, linetype = "Degree of functional coupling")) +
     geom_line(aes(y = hp, linetype = "Harmonic power")) +
     xlab("") +
     ylab("") +


### PR DESCRIPTION
Hi @nasserdr 

In this PR, I propose 2 minor changes:

### 1. readr version

**Problem**
I encountered an error when trying to use `digiRhythm::import_raw_activity_data`, telling me that the option `show_col_types` does not exist. It is used here:

https://github.com/nasserdr/digiRhythm/blob/28404cc37ac330ed3b8690148c351f47471b83ca/R/import_raw_activity_data.R#L91-L94

**Solution**
This option was indeed added in `readr` quite recently (v2.0.1), however there was no version specification in the `DESCRIPTION` file, so I added a minimal version requirement in d1e068c09e70da41439abf8a94ce48f0d4f10ee4.

### 2. DFC legend

**Problem**
The legend in the `dfc` plot mentioned the value is in %. However, I think the scale is a proportion (which makes sense in this case to compare HP and DFC visually.

**Solution**
Removed the % from legend in f1ab3d073426b0f312ef56069745d907d36461d1.